### PR TITLE
fix: re-adapt skills to skill-creator standards

### DIFF
--- a/.claude/skills/add-repo-override/SKILL.md
+++ b/.claude/skills/add-repo-override/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: add-repo-override
-description: Add a per-repo settings override to overrides.json
+description: >-
+  Add a per-repo settings override to overrides.json so a specific
+  repository can deviate from the baseline. Use this skill whenever the
+  user wants to customize settings for one repo, add an exception, or
+  says "this repo needs different branch protection" or "override the
+  wiki setting for this repo".
+disable-model-invocation: true
 user-invocable: true
+argument-hint: "<repo-name> <setting-path> <value>"
 ---
 
 # Add Repository Override

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: audit
-description: Run a dry-run settings audit across all repositories
-user-invocable: true
+description: >-
+  Run a dry-run settings audit across all repositories to detect drift
+  from baseline. Use this skill whenever the user wants to check repo
+  settings, find drift, audit governance, or says "are all repos in
+  sync?" or "check settings across the org".
 disable-model-invocation: true
+user-invocable: true
 ---
 
 # Audit Repository Settings

--- a/.claude/skills/exclude-repo/SKILL.md
+++ b/.claude/skills/exclude-repo/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: exclude-repo
-description: Exclude a repository from settings governance
+description: >-
+  Exclude a repository from settings governance so the sync script
+  skips it entirely. Use this skill whenever the user wants to remove
+  a repo from governance, stop syncing a repo, or says "don't manage
+  this repo" or "exclude my-fork from settings sync".
+disable-model-invocation: true
 user-invocable: true
+argument-hint: "<repo-name>"
 ---
 
 # Exclude Repository

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,9 +1,14 @@
 ---
 name: ship
-description: Update docs, commit, create PR, monitor CI and reviews, address feedback, merge
+description: >-
+  End-to-end PR lifecycle: update docs, commit, create PR, monitor CI,
+  address CodeRabbit and Copilot reviews, and merge. Use this skill
+  whenever the user says "ship it", "send a PR", "commit and merge",
+  "push this", or wants to finalize and land their changes. Pass a PR
+  number to resume monitoring an existing PR.
+disable-model-invocation: true
 user-invocable: true
 argument-hint: "[optional PR number to resume monitoring]"
-allowed-tools: Read, Write, Edit, Bash, Glob, Grep, Agent
 ---
 
 # Ship — Commit, Monitor, Fix, Merge


### PR DESCRIPTION
## Summary

- Remove `allowed-tools` from skill frontmatter (skills inherit all capabilities)
- Add `disable-model-invocation: true` to all skills (side-effect workflows)
- Add `argument-hint` to `/add-repo-override` and `/exclude-repo`
- Make descriptions trigger-focused with "Use this skill whenever..." phrasing

## Test plan

- [ ] Skills appear correctly in `/` autocomplete