### PR TITLE
fix: align CodeRabbit and Copilot review configs with other repos

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,8 @@
+language: en-US
 reviews:
   auto_review:
     enabled: true
+    drafts: false
   path_instructions:
     - path: "scripts/**/*.sh"
       instructions: |
@@ -33,3 +35,5 @@ reviews:
     - "!**/*.png"
     - "!**/*.gif"
     - "!**/*.jpg"
+chat:
+  auto_reply: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,6 @@
-# Review Priorities
+# GitHub Copilot Code Review Instructions
+
+## Review Priority
 
 1. Shell script quality: shellcheck and shellharden compliance, proper
    quoting, error handling (set -euo pipefail), no hardcoded tokens
@@ -12,3 +14,12 @@
    permissions, no script injection
 6. Markdown quality: 120 char line limit, fenced code blocks, accurate
    documentation
+
+## Expectations
+
+- All shell scripts must pass shellcheck and shellharden without
+  suppressions.
+- Variables must be quoted (`"$VAR"`), braces only when needed.
+- No hardcoded credentials, account IDs, or tokens in any file.
+- Conventional commits required for all changes.
+- Fix lint violations directly instead of adding ignore comments.


### PR DESCRIPTION
## Summary

- Add `language: en-US` and `chat: auto_reply: true` to `.coderabbit.yaml` to match other repos
- Add `drafts: false` to auto_review settings in `.coderabbit.yaml`
- Restructure `.github/copilot-instructions.md` with proper H1 header, `## Review Priority` and `## Expectations` sections

## Test plan

- [ ] Verify CodeRabbit picks up the language and chat settings on next PR review
- [ ] Verify Copilot code review still triggers with restructured instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review automation configuration to exclude draft pull requests from automatic reviews and enabled automatic chat reply functionality.
  * Established comprehensive code review standards documentation with explicit requirements for code quality validation, security practices, and standardized commit conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->